### PR TITLE
docs: add quick start demo GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ cd go-rest-api-boilerplate
 make quick-start
 ```
 
+<div align="center">
+  <img src="https://vahiiiid.github.io/go-rest-api-docs/images/quick-start-light.gif" alt="Quick Start Demo" width="800">
+</div>
+
 **🎉 Done!** Your API is now running at:
 - **API Base URL:** http://localhost:8080/api/v1
 - **Swagger UI:** http://localhost:8080/swagger/index.html


### PR DESCRIPTION
- Add animated GIF showing terminal quick-start process
- Place GIF after one-command setup instructions
- Use GitHub Pages hosted image for reliability
- Improve visual appeal and user engagement