### PR TITLE
Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities. Which versions are eligible for receiving such patches depends on the CVSS v3.0 Rating:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+The go-rest-api-boilerplate team and community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/vahiiiid/go-rest-api-boilerplate/security/advisories/new) tab.
+
+The go-rest-api-boilerplate team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+### What to include in your report
+
+Please include the following information in your security report:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+- We will respond to your report within 72 hours with our evaluation of the report and an expected resolution date
+- If you have followed the instructions above, we will not take any legal action against you regarding the report
+- We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission
+- We will keep you informed of the progress towards resolving the problem
+- In the public disclosure, we will give your name as the discoverer of the problem (unless you desire otherwise)


### PR DESCRIPTION
## Description
This PR adds a comprehensive security policy to the repository to establish clear guidelines for reporting security vulnerabilities.

## Changes
- ✅ Added  file in the root directory
- ✅ Included supported versions table
- ✅ Provided clear vulnerability reporting instructions
- ✅ Added GitHub Security Advisory integration
- ✅ Defined response timeline and communication process

## Testing
- [x] Verified file is properly formatted
- [x] Confirmed GitHub will recognize the security policy

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Closes #42