### PR TITLE
upgrade GO version #37

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.23']
+        go-version: ['1.25']
 
     steps:
     - name: Checkout code
@@ -74,7 +74,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Install swag
       run: go install github.com/swaggo/swag/cmd/swag@latest
@@ -99,7 +99,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Install swag
       run: go install github.com/swaggo/swag/cmd/swag@latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ The first production-ready release of GRAB - Go REST API Boilerplate.
 - Graceful shutdown handling
 
 ### Technical Stack
-- **Language**: Go 1.23+
+- **Language**: Go 1.25
 - **Framework**: Gin Web Framework
 - **ORM**: GORM
 - **Database**: PostgreSQL 15

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Development stage with hot-reload
 # Using Debian-based image for better CGO/SQLite compatibility
-FROM golang:1.23-bookworm AS development
+FROM golang:1.25-bookworm AS development
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -38,7 +38,7 @@ RUN chmod +x scripts/app_entrypoint.sh
 ENTRYPOINT ["./scripts/app_entrypoint.sh"]
 
 # Production builder stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ make run-binary        # Build and run binary directly (requires Go on host)
 
 ### Without Docker (Native Development)
 
-**Want to run without Docker?** You'll need Go 1.23+ installed on your machine.
+**Want to run without Docker?** You'll need Go 1.25 installed on your machine.
 
 See the **[Manual Setup Guide](https://vahiiiid.github.io/go-rest-api-docs/SETUP/)** for detailed instructions on:
 - Installing Go and development tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vahiiiid/go-rest-api-boilerplate
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/gin-contrib/cors v1.5.0


### PR DESCRIPTION
## 🧩 Summary

Upgraded the project from **Go 1.23 (EOL)** to **Go 1.25**, following the Go release policy which supports only the two most recent versions.

## 🔧 Changes Made

- `go.mod`: set `go 1.25.0`
- `Dockerfile`: updated to `golang:1.25-bookworm`
- `.github/workflows/ci.yml`: CI updated to test against Go 1.25
- `README.md`: updated Go version references

## 🧪 Testing

- ✅ Ran `make test` — all tests passed
- ✅ Started dev environment with `make quick-start`
- ✅ Verified health endpoint works

## 📌 Closes

Closes #37 
