### PR TITLE
chore: remove /docs/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,3 @@ api/docs/docs.go
 api/docs/swagger.json
 api/docs/swagger.yaml
 
-# Documentation (separate repo)
-/docs/
-


### PR DESCRIPTION
## Summary
Removes the `/docs/` entry from `.gitignore` file.

## Rationale
- Documentation is maintained in a separate repository (`go-rest-api-docs`)
- This change allows potential local docs folders without being automatically ignored
- Aligns with the project's documentation strategy of keeping docs separate

## Changes
- Removed `/docs/` line from `.gitignore`

## Type of Change
- [x] Maintenance/Chore (non-breaking change that improves project structure)

## Testing
No testing required for this gitignore change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `/docs/` entry (and its comment) from `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c357e5790aa5b206a89fb045e20a2b00d8351cd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->