### PR TITLE
fix: missing indent in docker compose api volume exclusion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     volumes:
       # Mount source code for hot-reload in development
       - ./:/app
-      - /app/tmp  # Exclude tmp directory
+        - /app/tmp  # Exclude tmp directory
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Description
Missing indent in volume exclusion leads to container not running under some Linux distros (tmp folder still being mounted):

pse_api  | building...
pse_api  | error obtaining VCS status: exit status 128
pse_api  |      Use -buildvcs=false to disable VCS stamping.
pse_api  | failed to build, error: exit status 1
pse_api  | running...
pse_api  | /bin/sh: 1: /app/tmp/main: not found
pse_api  | Process Exit with Code: 127

## Type of Change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Postman/API testing

**Test Configuration**:
- Go version: 1.23.12
- Database: Postgres
- OS: Linux Mint and Arch Linux

## API Changes (if applicable)
- [ ] New endpoints added
- [ ] Existing endpoints modified
- [ ] Database schema changes
- [ ] Authentication/authorization changes

**Endpoints affected:**
- 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Add any other context about the pull request here.