### PR TITLE
fix: environment variables now override YAML config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,38 +119,33 @@ func LoadConfig(configPath string) (*Config, error) {
 
 // This ensures ENV vars take precedence over config file values
 func bindEnvVariables(v *viper.Viper) {
-	// App configuration
-	v.BindEnv("app.name", "APP_NAME")
-	v.BindEnv("app.environment", "APP_ENVIRONMENT")
-	v.BindEnv("app.debug", "APP_DEBUG")
+	envBindings := map[string]string{
+		"app.name":               "APP_NAME",
+		"app.environment":        "APP_ENVIRONMENT",
+		"app.debug":              "APP_DEBUG",
+		"database.host":          "DATABASE_HOST",
+		"database.port":          "DATABASE_PORT",
+		"database.user":          "DATABASE_USER",
+		"database.password":      "DATABASE_PASSWORD",
+		"database.name":          "DATABASE_NAME",
+		"database.sslmode":       "DATABASE_SSLMODE",
+		"jwt.secret":             "JWT_SECRET",
+		"jwt.ttlhours":           "JWT_TTLHOURS",
+		"server.port":            "SERVER_PORT",
+		"server.readtimeout":     "SERVER_READTIMEOUT",
+		"server.writetimeout":    "SERVER_WRITETIMEOUT",
+		"server.idletimeout":     "SERVER_IDLETIMEOUT",
+		"server.shutdowntimeout": "SERVER_SHUTDOWNTIMEOUT",
+		"server.maxheaderbytes":  "SERVER_MAXHEADERBYTES",
+		"logging.level":          "LOGGING_LEVEL",
+		"ratelimit.enabled":      "RATELIMIT_ENABLED",
+		"ratelimit.requests":     "RATELIMIT_REQUESTS",
+		"ratelimit.window":       "RATELIMIT_WINDOW",
+	}
 
-	// Database configuration
-	v.BindEnv("database.host", "DATABASE_HOST")
-	v.BindEnv("database.port", "DATABASE_PORT")
-	v.BindEnv("database.user", "DATABASE_USER")
-	v.BindEnv("database.password", "DATABASE_PASSWORD")
-	v.BindEnv("database.name", "DATABASE_NAME")
-	v.BindEnv("database.sslmode", "DATABASE_SSLMODE")
-
-	// JWT configuration
-	v.BindEnv("jwt.secret", "JWT_SECRET")
-	v.BindEnv("jwt.ttlhours", "JWT_TTLHOURS")
-
-	// Server configuration
-	v.BindEnv("server.port", "SERVER_PORT")
-	v.BindEnv("server.readtimeout", "SERVER_READTIMEOUT")
-	v.BindEnv("server.writetimeout", "SERVER_WRITETIMEOUT")
-	v.BindEnv("server.idletimeout", "SERVER_IDLETIMEOUT")
-	v.BindEnv("server.shutdowntimeout", "SERVER_SHUTDOWNTIMEOUT")
-	v.BindEnv("server.maxheaderbytes", "SERVER_MAXHEADERBYTES")
-
-	// Logging configuration
-	v.BindEnv("logging.level", "LOGGING_LEVEL")
-
-	// Rate limit configuration
-	v.BindEnv("ratelimit.enabled", "RATELIMIT_ENABLED")
-	v.BindEnv("ratelimit.requests", "RATELIMIT_REQUESTS")
-	v.BindEnv("ratelimit.window", "RATELIMIT_WINDOW")
+	for key, env := range envBindings {
+		_ = v.BindEnv(key, env)
+	}
 }
 
 // GetLogLevel converts string log level to slog.Level


### PR DESCRIPTION
## Description
Resolves issue where YAML config values were overriding environment variables even though they were right during `viper.Unmarshal()`. Based on https://github.com/spf13/viper/issues/761

## Type of Change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [x] Manual testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules