### PR TITLE
refactor: rename ctx package to contextutil to avoid stdlib collision

### DIFF
--- a/internal/contextutil/context.go
+++ b/internal/contextutil/context.go
@@ -1,4 +1,4 @@
-package ctx
+package contextutil
 
 import (
 	"fmt"

--- a/internal/contextutil/context_test.go
+++ b/internal/contextutil/context_test.go
@@ -1,4 +1,4 @@
-package ctx
+package contextutil
 
 import (
 	"net/http/httptest"

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/vahiiiid/go-rest-api-boilerplate/internal/auth"
-	"github.com/vahiiiid/go-rest-api-boilerplate/internal/ctx"
+	"github.com/vahiiiid/go-rest-api-boilerplate/internal/contextutil"
 	apiErrors "github.com/vahiiiid/go-rest-api-boilerplate/internal/errors"
 )
 
@@ -136,7 +136,7 @@ func (h *Handler) GetUser(c *gin.Context) {
 		return
 	}
 
-	if !ctx.CanAccessUser(c, uint(id)) {
+	if !contextutil.CanAccessUser(c, uint(id)) {
 		_ = c.Error(apiErrors.Forbidden("Forbidden user ID"))
 		return
 	}
@@ -180,7 +180,7 @@ func (h *Handler) UpdateUser(c *gin.Context) {
 	}
 
 	// Authorization check
-	if !ctx.CanAccessUser(c, uint(id)) {
+	if !contextutil.CanAccessUser(c, uint(id)) {
 		_ = c.Error(apiErrors.Forbidden("Forbidden user ID"))
 		return
 	}
@@ -232,7 +232,7 @@ func (h *Handler) DeleteUser(c *gin.Context) {
 	}
 
 	// Authorization check
-	if !ctx.CanAccessUser(c, uint(id)) {
+	if !contextutil.CanAccessUser(c, uint(id)) {
 		_ = c.Error(apiErrors.Forbidden("Forbidden user ID"))
 		return
 	}
@@ -310,7 +310,7 @@ func (h *Handler) RefreshToken(c *gin.Context) {
 // @Failure 500 {object} errors.APIError "Failed to logout"
 // @Router /api/v1/auth/logout [post]
 func (h *Handler) Logout(c *gin.Context) {
-	userID := ctx.GetUserID(c)
+	userID := contextutil.GetUserID(c)
 	if userID == 0 {
 		_ = c.Error(apiErrors.Unauthorized("user not authenticated"))
 		return

--- a/tests/context_test.go
+++ b/tests/context_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vahiiiid/go-rest-api-boilerplate/internal/auth"
-	"github.com/vahiiiid/go-rest-api-boilerplate/internal/ctx"
+	"github.com/vahiiiid/go-rest-api-boilerplate/internal/contextutil"
 )
 
 func TestGetUser(t *testing.T) {
@@ -18,7 +18,7 @@ func TestGetUser(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		result := ctx.GetUser(c)
+		result := contextutil.GetUser(c)
 		assert.NotNil(t, result)
 		assert.Equal(t, uint(42), result.UserID)
 		assert.Equal(t, "test@example.com", result.Email)
@@ -27,7 +27,7 @@ func TestGetUser(t *testing.T) {
 	t.Run("returns nil when not present", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		result := ctx.GetUser(c)
+		result := contextutil.GetUser(c)
 		assert.Nil(t, result)
 	})
 
@@ -35,7 +35,7 @@ func TestGetUser(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 		c.Set(auth.KeyUser, "not-a-claims-struct")
 
-		result := ctx.GetUser(c)
+		result := contextutil.GetUser(c)
 		assert.Nil(t, result)
 	})
 }
@@ -48,7 +48,7 @@ func TestMustGetUser(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		result, err := ctx.MustGetUser(c)
+		result, err := contextutil.MustGetUser(c)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 		assert.Equal(t, uint(42), result.UserID)
@@ -58,7 +58,7 @@ func TestMustGetUser(t *testing.T) {
 	t.Run("returns error when not present", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		result, err := ctx.MustGetUser(c)
+		result, err := contextutil.MustGetUser(c)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "user not found in context")
@@ -73,14 +73,14 @@ func TestGetUserID(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		userID := ctx.GetUserID(c)
+		userID := contextutil.GetUserID(c)
 		assert.Equal(t, uint(42), userID)
 	})
 
 	t.Run("returns 0 when not present", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		userID := ctx.GetUserID(c)
+		userID := contextutil.GetUserID(c)
 		assert.Equal(t, uint(0), userID)
 	})
 
@@ -88,7 +88,7 @@ func TestGetUserID(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 		c.Set(auth.KeyUser, "not-a-claims-struct")
 
-		userID := ctx.GetUserID(c)
+		userID := contextutil.GetUserID(c)
 		assert.Equal(t, uint(0), userID)
 	})
 }
@@ -101,7 +101,7 @@ func TestMustGetUserID(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		userID, err := ctx.MustGetUserID(c)
+		userID, err := contextutil.MustGetUserID(c)
 		assert.NoError(t, err)
 		assert.Equal(t, uint(42), userID)
 	})
@@ -109,7 +109,7 @@ func TestMustGetUserID(t *testing.T) {
 	t.Run("returns error when not present", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		userID, err := ctx.MustGetUserID(c)
+		userID, err := contextutil.MustGetUserID(c)
 		assert.Error(t, err)
 		assert.Equal(t, uint(0), userID)
 		assert.Contains(t, err.Error(), "user ID not found in context")
@@ -120,7 +120,7 @@ func TestMustGetUserID(t *testing.T) {
 		claims := &auth.Claims{UserID: 0, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		userID, err := ctx.MustGetUserID(c)
+		userID, err := contextutil.MustGetUserID(c)
 		assert.Error(t, err)
 		assert.Equal(t, uint(0), userID)
 		assert.Contains(t, err.Error(), "user ID not found in context")
@@ -135,14 +135,14 @@ func TestGetEmail(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		email := ctx.GetEmail(c)
+		email := contextutil.GetEmail(c)
 		assert.Equal(t, "test@example.com", email)
 	})
 
 	t.Run("returns empty string when not present", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		email := ctx.GetEmail(c)
+		email := contextutil.GetEmail(c)
 		assert.Equal(t, "", email)
 	})
 
@@ -150,7 +150,7 @@ func TestGetEmail(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 		c.Set(auth.KeyUser, "not-a-claims-struct")
 
-		email := ctx.GetEmail(c)
+		email := contextutil.GetEmail(c)
 		assert.Equal(t, "", email)
 	})
 }
@@ -163,14 +163,14 @@ func TestIsAuthenticated(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		authenticated := ctx.IsAuthenticated(c)
+		authenticated := contextutil.IsAuthenticated(c)
 		assert.True(t, authenticated)
 	})
 
 	t.Run("returns false when user is not present", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		authenticated := ctx.IsAuthenticated(c)
+		authenticated := contextutil.IsAuthenticated(c)
 		assert.False(t, authenticated)
 	})
 
@@ -178,7 +178,7 @@ func TestIsAuthenticated(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 		c.Set(auth.KeyUser, "not-a-claims-struct")
 
-		authenticated := ctx.IsAuthenticated(c)
+		authenticated := contextutil.IsAuthenticated(c)
 		assert.False(t, authenticated)
 	})
 }
@@ -191,7 +191,7 @@ func TestCanAccessUser(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		canAccess := ctx.CanAccessUser(c, 42)
+		canAccess := contextutil.CanAccessUser(c, 42)
 		assert.True(t, canAccess)
 	})
 
@@ -200,14 +200,14 @@ func TestCanAccessUser(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com"}
 		c.Set(auth.KeyUser, claims)
 
-		canAccess := ctx.CanAccessUser(c, 43)
+		canAccess := contextutil.CanAccessUser(c, 43)
 		assert.False(t, canAccess)
 	})
 
 	t.Run("returns false when user is not authenticated", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		canAccess := ctx.CanAccessUser(c, 42)
+		canAccess := contextutil.CanAccessUser(c, 42)
 		assert.False(t, canAccess)
 	})
 }
@@ -220,14 +220,14 @@ func TestGetUserName(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com", Name: "John Doe"}
 		c.Set(auth.KeyUser, claims)
 
-		userName := ctx.GetUserName(c)
+		userName := contextutil.GetUserName(c)
 		assert.Equal(t, "John Doe", userName)
 	})
 
 	t.Run("returns empty string when not present", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		userName := ctx.GetUserName(c)
+		userName := contextutil.GetUserName(c)
 		assert.Equal(t, "", userName)
 	})
 
@@ -235,7 +235,7 @@ func TestGetUserName(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 		c.Set(auth.KeyUser, "not-a-claims-struct")
 
-		userName := ctx.GetUserName(c)
+		userName := contextutil.GetUserName(c)
 		assert.Equal(t, "", userName)
 	})
 }
@@ -248,14 +248,14 @@ func TestHasRole(t *testing.T) {
 		claims := &auth.Claims{UserID: 42, Email: "test@example.com", Name: "John Doe"}
 		c.Set(auth.KeyUser, claims)
 
-		hasRole := ctx.HasRole(c, "admin")
+		hasRole := contextutil.HasRole(c, "admin")
 		assert.False(t, hasRole) // Currently returns false as roles are not implemented
 	})
 
 	t.Run("returns false when user is not present", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 
-		hasRole := ctx.HasRole(c, "admin")
+		hasRole := contextutil.HasRole(c, "admin")
 		assert.False(t, hasRole)
 	})
 
@@ -263,7 +263,7 @@ func TestHasRole(t *testing.T) {
 		c, _ := gin.CreateTestContext(nil)
 		c.Set(auth.KeyUser, "not-a-claims-struct")
 
-		hasRole := ctx.HasRole(c, "admin")
+		hasRole := contextutil.HasRole(c, "admin")
 		assert.False(t, hasRole)
 	})
 }


### PR DESCRIPTION
## Summary
This PR renames the `internal/ctx` package to `internal/contextutil` to avoid collision with Go's standard library conventions.

## Changes Made
- ✅ Renamed directory from `internal/ctx` to `internal/contextutil`
- ✅ Updated package declarations in all files within the package
- ✅ Updated all import statements across the codebase
- ✅ Updated all usages from `ctx.` to `contextutil.` in handlers and tests
- ✅ All tests pass (`make test`)
- ✅ No linting errors (`make lint`)

## Files Changed
- `internal/contextutil/context.go` (renamed from `internal/ctx/context.go`)
- `internal/contextutil/context_test.go` (renamed from `internal/ctx/context_test.go`)
- `internal/user/handler.go` (updated imports and usages)
- `tests/context_test.go` (updated imports and usages)

## Testing
✅ All unit tests pass
✅ API endpoints tested and working:
- Health endpoint
- Register endpoint
- Login endpoint
- Get user by ID endpoint

Closes #87

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the `internal/ctx` package to `internal/contextutil` and updates all imports and usages across handlers and tests.
> 
> - **Backend**:
>   - **Context utilities**: Rename/move `internal/ctx` to `internal/contextutil`; update package name in `internal/contextutil/context.go` and its tests.
>   - **User handler**: Replace `ctx.*` with `contextutil.*` and update imports in `internal/user/handler.go`.
> - **Tests**:
>   - Update imports/usages from `ctx` to `contextutil` in `internal/contextutil/context_test.go` and `tests/context_test.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45072df308b8c7131382c901d64a365b73ef85ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->