### PR TITLE
chore: unify AI assistant guidelines around a single source of truth

### DIFF
--- a/.agents/AI-CONFIG.md
+++ b/.agents/AI-CONFIG.md
@@ -1,0 +1,63 @@
+# GRAB — AI Configuration Guide
+
+This document explains where AI configuration lives, which tool reads which file, and where to put new content. It exists so that when a project convention changes, the person (or agent) making the change knows every file that needs to move together.
+
+## File Inventory
+
+| File | Tool(s) | Loading condition | Content type |
+|---|---|---|---|
+| `AGENTS.md` | Codex, JetBrains AI, Claude Code (via `@import`), any AGENTS.md-compliant tool | Always | **Source of truth.** Full project guidelines: architecture, workflow, conventions, common tasks |
+| `CLAUDE.md` | Claude Code | Always | Single line: `@AGENTS.md` |
+| `CLAUDE.local.md` | Claude Code only | Always (gitignored) | Personal overrides — never committed |
+| `.github/copilot-instructions.md` | GitHub Copilot (VS Code, JetBrains, Visual Studio) | Always | Condensed copy of `AGENTS.md`, manually synced |
+| `.cursor/rules/grab.mdc` | Cursor | Always (`alwaysApply: true`) | Condensed copy of `AGENTS.md`, manually synced |
+| `.windsurf/rules/grab.md` | Windsurf | Always ("Always On") | Condensed copy of `AGENTS.md`, manually synced |
+
+## Why Condensed Copies Instead of Imports
+
+`AGENTS.md` is the canonical, comprehensive guide. Claude Code officially supports importing it with `@AGENTS.md` syntax in `CLAUDE.md`, so that file stays a one-liner.
+
+Copilot, Cursor, and Windsurf don't support that kind of cross-file import, and their rule files are meant to be short (large rule files either get truncated or eat context budget on every prompt). So `.github/copilot-instructions.md`, `.cursor/rules/grab.mdc`, and `.windsurf/rules/grab.md` are deliberately condensed, hand-maintained adapters — not full copies of `AGENTS.md`.
+
+## Maintenance Rule
+
+**`AGENTS.md` is the source of truth. When you change a project-wide convention there — architecture pattern, error-handling API, migration naming, testing pattern, commit format — check whether the same convention appears in the three condensed adapters and update it there too:**
+
+- `.github/copilot-instructions.md`
+- `.cursor/rules/grab.mdc`
+- `.windsurf/rules/grab.md`
+
+Each of those files carries a comment at the top pointing back to `AGENTS.md` as the source. They don't need to match `AGENTS.md` word-for-word (they're condensed on purpose), but they must not contradict it.
+
+Content that's only relevant to one tool (a Cursor-only setting, a Copilot IDE-support note) can live only in that tool's file.
+
+## Personal Local Overrides (Not Committed)
+
+### `CLAUDE.local.md` (Claude Code)
+
+Copy `CLAUDE.local.md.example` to `CLAUDE.local.md` in the repo root. Claude Code reads it automatically in addition to `CLAUDE.md`. It's gitignored.
+
+### Copilot (VS Code Settings)
+
+Copilot personal preferences are set in VS Code User Settings (not per-repo, so not gitignored):
+
+1. Open VS Code Settings → search for `github.copilot.chat.codeGeneration.instructions`
+2. Add entries like:
+   ```json
+   "github.copilot.chat.codeGeneration.instructions": [
+     { "text": "I prefer table-driven tests with explicit subtests." }
+   ]
+   ```
+
+### Cursor
+
+Create `.cursor/rules/personal.mdc` (gitignored per your own global gitignore, or keep it out of version control manually) with `alwaysApply: true` and your preferences.
+
+## How Each Tool Reads Configuration
+
+- **Codex**: reads `AGENTS.md` natively, no import needed.
+- **Claude Code**: reads `CLAUDE.md` (which imports `AGENTS.md` via `@AGENTS.md`), plus `CLAUDE.local.md` if present.
+- **GitHub Copilot**: reads `.github/copilot-instructions.md` automatically in Copilot Chat (VS Code, JetBrains IDEs, Visual Studio).
+- **Cursor**: reads `.cursor/rules/*.mdc` files; `grab.mdc` has `alwaysApply: true`.
+- **Windsurf**: reads `.windsurf/rules/*.md` files marked "Always On".
+- **JetBrains AI Assistant**: reads `AGENTS.md` directly.

--- a/.cursor/rules/grab.mdc
+++ b/.cursor/rules/grab.mdc
@@ -4,8 +4,11 @@ alwaysApply: true
 
 # GRAB Development Rules for Cursor
 
-**Version**: v2.0.0  
-**Last Updated**: 2025-12-10  
+<!-- Condensed from AGENTS.md (repo root), the canonical source of truth. -->
+<!-- When a project-wide convention changes there, sync it here too — see .agents/AI-CONFIG.md. -->
+
+**Version**: v2.0.0
+**Last Updated**: 2025-12-10
 **Purpose**: Developer guidelines for building APIs with GRAB (Go REST API Boilerplate)
 
 ---

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,8 @@
 # GitHub Copilot Instructions for GRAB (Go REST API Boilerplate)
 
+<!-- Condensed from AGENTS.md (repo root), the canonical source of truth. -->
+<!-- When a project-wide convention changes there, sync it here too — see .agents/AI-CONFIG.md. -->
+
 **Version**: v2.0.0  
 **Last Updated**: 2025-12-10  
 **Purpose**: Developer-focused guidelines for building APIs with GRAB

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ api/docs/docs.go
 api/docs/swagger.json
 api/docs/swagger.yaml
 
+# Documentation site (github.com/vahiiiid/go-rest-api-docs), cloned locally for reference
+/docs/
+
+# Personal AI assistant overrides (not for the team)
+CLAUDE.local.md
+

--- a/.windsurf/rules/grab.md
+++ b/.windsurf/rules/grab.md
@@ -1,5 +1,8 @@
 # GRAB Development Rules for Windsurf
 
+<!-- Condensed from AGENTS.md (repo root), the canonical source of truth. -->
+<!-- When a project-wide convention changes there, sync it here too — see .agents/AI-CONFIG.md. -->
+
 **Version**: v2.0.0  
 **Last Updated**: 2025-12-10  
 **Purpose**: Developer guidelines for building APIs with GRAB (Go REST API Boilerplate)  

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@
 **Last Updated**: 2025-12-10  
 **Purpose**: Universal AI assistant guidelines for GRAB (Go REST API Boilerplate)
 
-> This file follows the OpenAI AGENTS.md standard and is compatible with all major AI coding assistants including GitHub Copilot, Cursor, Windsurf, JetBrains AI, and others.
+> This file follows the [AGENTS.md standard](https://agents.md) (stewarded by the Agentic AI Foundation) and is compatible with all major AI coding assistants including GitHub Copilot, Cursor, Windsurf, Claude Code, JetBrains AI, and others.
+>
+> **This is the canonical source of truth for GRAB's AI guidelines.** Claude Code reads it via `CLAUDE.md`'s `@AGENTS.md` import; Copilot, Cursor, and Windsurf each keep a condensed, manually-synced adapter. See [`.agents/AI-CONFIG.md`](.agents/AI-CONFIG.md) for the full file map and the rule for keeping them in sync.
 
 ---
 

--- a/CLAUDE.local.md.example
+++ b/CLAUDE.local.md.example
@@ -1,0 +1,13 @@
+# My Personal AI Preferences — Claude Code
+
+<!-- This file is gitignored. Only you see this. -->
+<!-- Claude reads this in addition to CLAUDE.md (which imports AGENTS.md). -->
+<!-- Copy this to CLAUDE.local.md and customize. -->
+
+## Example: Code style preferences
+<!-- Uncomment and customize as needed:
+
+- I prefer `assert` over `require` in tests unless the test truly can't continue.
+- Always run `make lint-fix` before showing me a diff, not just before committing.
+
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# GRAB — Claude Code Instructions
+
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,10 @@ When making significant changes to the codebase:
 - Update the README.md if it affects quick start or basic usage
 - Consider updating the full documentation in the docs repository
 
+#### Updating AI Assistant Guidelines
+
+`AGENTS.md` is the canonical source of truth for GRAB's AI coding guidelines. If your change affects a project-wide convention (architecture pattern, error handling, migration naming, testing pattern, commit format), update `AGENTS.md` first, then check whether `.github/copilot-instructions.md`, `.cursor/rules/grab.mdc`, and `.windsurf/rules/grab.md` need the same update — see [`.agents/AI-CONFIG.md`](.agents/AI-CONFIG.md) for the full file map and sync rule. Claude Code reads `AGENTS.md` automatically via `CLAUDE.md`, so it needs no separate edit.
+
 ## Feature Requests
 
 - Check existing issues first

--- a/README.md
+++ b/README.md
@@ -29,18 +29,22 @@ Production-ready in 90 seconds. No headaches, just clean code.
 
 GRAB is designed to work seamlessly with your favorite AI coding assistants:
 
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-ready-D97757?logo=anthropic&logoColor=white)](CLAUDE.md)
 [![GitHub Copilot](https://img.shields.io/badge/GitHub%20Copilot-optimized-7F52FF?logo=github&logoColor=white)](https://github.com/features/copilot)
 [![Cursor](https://img.shields.io/badge/Cursor-ready-7C3AED?logo=cursor&logoColor=white)](https://cursor.sh/)
 [![Windsurf](https://img.shields.io/badge/Windsurf-supported-00C7B7?logoColor=white)](https://codeium.com/windsurf)
 [![GoLand](https://img.shields.io/badge/GoLand-dual%20AI-087CFA?logo=goland&logoColor=white)](https://www.jetbrains.com/go/)
-[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compliant-orange?logo=openai&logoColor=white)](AGENTS.md)
+[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compliant-orange?logoColor=white)](AGENTS.md)
 
-**Out-of-the-box AI integration** with comprehensive guidelines for:
+**Out-of-the-box AI integration**, all built from one canonical guide — [`AGENTS.md`](AGENTS.md) — with tool-specific adapters for:
+- **Claude Code** (via [`CLAUDE.md`](CLAUDE.md), which imports `AGENTS.md` directly)
 - **GitHub Copilot** (VS Code, GoLand, Visual Studio)
 - **Cursor IDE** (with dedicated `.cursor/rules/`)
 - **Windsurf IDE** (with dedicated `.windsurf/rules/`)
 - **JetBrains AI** (via AGENTS.md standard)
-- Any AI assistant supporting AGENTS.md standard
+- Any AI assistant supporting the [AGENTS.md standard](https://agents.md)
+
+`AGENTS.md` is the single source of truth; the Copilot/Cursor/Windsurf files are condensed, manually-synced adapters. See [`.agents/AI-CONFIG.md`](.agents/AI-CONFIG.md) for the full file map and the rule for keeping them in sync.
 
 > **Note**: GoLand users get dual AI support through both GitHub Copilot (via `.github/copilot-instructions.md`) and JetBrains AI (via `AGENTS.md`). No IDE-specific configuration needed.
 
@@ -63,7 +67,7 @@ make quick-start  # ← One command. 90 seconds. You're building features.
 **This is the real deal.** The production-grade boilerplate you wish you had from day one:
 
 ✅ **Clean Architecture** — Handler → Service → Repository (GO industry standard)  
-✅ **AI-Optimized Guidelines** — Built-in rules for GitHub Copilot, Cursor, Windsurf & AGENTS.md  
+✅ **AI-Optimized Guidelines** — One canonical `AGENTS.md`, with adapters for Claude Code, GitHub Copilot, Cursor & Windsurf  
 ✅ **Security & JWT Auth** — OAuth 2.0 BCP compliant with refresh token rotation, rate limiting, CORS  
 ✅ **Role-Based Access Control** — Many-to-many RBAC with JWT integration and secure admin CLI  
 ✅ **Database Migrations** — PostgreSQL with version control & rollback  


### PR DESCRIPTION
## Summary

Closes #111.

- `AGENTS.md` is now explicitly the canonical source of truth (header note + link), and its outdated "OpenAI standard" claim is corrected to the current [agents.md](https://agents.md) stewardship (Agentic AI Foundation).
- Added `CLAUDE.md` (`@AGENTS.md` import) so Claude Code gets the same first-class support Copilot/Cursor/Windsurf already have, plus a gitignored `CLAUDE.local.md.example` for personal overrides.
- Added `.agents/AI-CONFIG.md`: the file inventory and the explicit rule for which adapter files (`.github/copilot-instructions.md`, `.cursor/rules/grab.mdc`, `.windsurf/rules/grab.md`) need to be updated when a convention in `AGENTS.md` changes.
- Added a one-line sync-source comment to the top of each of those three adapters, pointing back at `AGENTS.md`.
- `README.md` and `CONTRIBUTING.md` updated to document the new structure instead of leaving it undiscoverable.
- `docs/` (the separately-cloned `go-rest-api-docs` repo, used locally for reference) is now explicitly gitignored — it was previously untracked only because it happens to carry its own nested `.git`, which is fragile.

## Not changed

Per `.agents/AI-CONFIG.md`, the three condensed adapters stay condensed, hand-maintained copies — not full duplicates of `AGENTS.md` — since Copilot/Cursor/Windsurf don't support cross-file imports and their rule files have practical size limits. Their actual guidance content is unchanged in this PR (verified against `internal/` that the error-handling pattern they already describe, `c.Error(apiErrors.FromGinValidation(err))`, matches the real code).

## Test plan

- [x] `git check-ignore -v docs/` confirms `docs/` is now ignored
- [x] Diff reviewed file-by-file; no unintended content rewrites
- [ ] CI (markdown-only change, no Go source touched)